### PR TITLE
feat(release): Remove commented-out code for pytest in Linux workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,7 +66,3 @@ jobs:
     - name: Docker waiting services
       run: |
         make containers-wait SERVICE=wave-app
-
-    # - name: Run tests with pytest
-    #   run: |
-    #     make test-fetch-data


### PR DESCRIPTION
This commit removes commented-out code for running tests with pytest in the Linux workflow. 